### PR TITLE
Fixed Crash when installing nokogiri 1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,24 +280,25 @@ In case if you are using mysql as database
 	sudo gem install bundler
 	sudo bundle install --deployment --without development test postgres aws
 
-If you can't build nokogiri 1.6.2 Do
+If you can't build nokogiri 1.6.2 do this:
 
-		brew install libxml2 libxslt
-		brew link libxml2 libxslt
+	brew install libxml2 libxslt
+	brew link libxml2 libxslt
 
-	then install libiconv from source
+then install libiconv from source
  
-		wget http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.13.1.tar.gz
-		tar xvfz libiconv-1.13.1.tar.gz
-		cd libiconv-1.13.1
-		./configure --prefix=/usr/local/Cellar/libiconv/1.13.1
-		make
-		sudo make install
-	finally we need to continue bundle install
+	wget http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.13.1.tar.gz
+	tar xvfz libiconv-1.13.1.tar.gz
+	cd libiconv-1.13.1
+	./configure --prefix=/usr/local/Cellar/libiconv/1.13.1
+	make
+	sudo make install
+	
+finally we need to continue bundle install
 		
-		sudo ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future bundle install --deployment --without development test mysql aws -- 
-				--with-iconv-lib=/usr/local/Cellar/libiconv/1.13.1/lib 
-				--with-iconv-include=/usr/local/Cellar/libiconv/1.13.1/include	
+	sudo bundle install --deployment --without development test mysql aws -- 
+		--with-iconv-lib=/usr/local/Cellar/libiconv/1.13.1/lib 
+		--with-iconv-include=/usr/local/Cellar/libiconv/1.13.1/include	
 
 If you see error with `version_sorter` gem run this:
 


### PR DESCRIPTION
https://gist.github.com/ludkiller/81bed4d585271c4e41a0
that,
If you have issues with 1.6.2.1 similar to the issue : https://github.com/WebEntity/Installation-guide-for-GitLab-on-OS-X/issues/16
