### PR TITLE
pkg-config is required to build Rugged

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you find any issues, please let me know or send PR with fix ;-) Thank you!
 
 ### 3. Install some prerequisites
 	
-	brew install icu4c git logrotate redis libxml2 cmake
+	brew install icu4c git logrotate redis libxml2 cmake pkg-config
 
 	ln -sfv /usr/local/opt/logrotate/*.plist ~/Library/LaunchAgents
 	launchctl load ~/Library/LaunchAgents/homebrew.mxcl.logrotate.plist


### PR DESCRIPTION
```
ERROR: pkg-config is required to build Rugged.
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```
