### PR TITLE
Information about default nginx.conf conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ Default nginx configuration has an example server on port 8080, same as Gitlab U
 Edit nginx configuration and comment out whole example server block for it to work together:
 
 ```
-sudo nano /etc/nginx/nginx.conf
+sudo nano /usr/local/etc/nginx/nginx.conf
 ```
 
 Copy the example site config:

--- a/README.md
+++ b/README.md
@@ -518,6 +518,13 @@ sudo mkdir -p /var/log/nginx/
 
 ### Site Configuration
 
+Default nginx configuration has an example server on port 8080, same as Gitlab Unicorn instance, which will collide and Gitlab won't start.
+Edit nginx configuration and comment out whole example server block for it to work together:
+
+```
+sudo nano /etc/nginx/nginx.conf
+```
+
 Copy the example site config:
 ```
 sudo cp lib/support/nginx/gitlab /usr/local/etc/nginx/servers/gitlab


### PR DESCRIPTION
Both Gitlab Unicorn and  default nginx try to bind on port 8080, one of the two will fail to start. We can avoid this problem by changing example nginx configuration to one without example server.
See Issue #56